### PR TITLE
updated updates.json file to new link

### DIFF
--- a/public/manifest.json
+++ b/public/manifest.json
@@ -11,7 +11,7 @@
   "browser_specific_settings": {
     "gecko": {
       "id": "{fb005b54-5431-46cc-a3b2-7b6291bbf7cd}",
-      "update_url": "https://raw.githubusercontent.com/imperviousai/beta-extension-release/main/updates.json"
+      "update_url": "https://raw.githubusercontent.com/imperviousai/imp-extension/master/updates.json"
     }
   },
   "chrome_url_overrides": {


### PR DESCRIPTION
Swapping the `updates.json` link to this repo's `updates.json`.  Getting rid of the beta-extensions-release repo soon. 