### PR TITLE
textarea input sets state to linebreak after state has been cleared

### DIFF
--- a/components/access/Onboard.jsx
+++ b/components/access/Onboard.jsx
@@ -403,7 +403,7 @@ function Onboard() {
             onClick={() => {
               setShowPasswordScreen(true);
             }}
-            className="w-1/5 inline-flex justify-center items-center px-8 py-3 border border-transparent text-base font-medium rounded-md shadow-sm text-white bg-primary hover:bg-primary-hover focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-primary"
+            className="w-2/5 inline-flex justify-center items-center px-8 py-3 border border-transparent text-base font-medium rounded-md shadow-sm text-white bg-primary hover:bg-primary-hover focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-primary"
           >
             New User
             <ChevronRightIcon className="h-5 w-5" />
@@ -411,7 +411,7 @@ function Onboard() {
           <button
             type="button"
             onClick={() => setShowingRecovery(true)}
-            className="w-1/5 inline-flex justify-center items-center px-8 py-2 mt-4 border-2 border-primary shadow-sm text-base font-medium rounded-md text-primary bg-white hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500"
+            className="w-2/5 inline-flex justify-center items-center px-8 py-2 mt-4 border-2 border-primary shadow-sm text-base font-medium rounded-md text-primary bg-white hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500"
           >
             Recovery <ChevronRightIcon className="h-5 w-5" />
           </button>

--- a/components/meeting/ConversationFooter.jsx
+++ b/components/meeting/ConversationFooter.jsx
@@ -88,6 +88,14 @@ const ConversationFooter = ({ sendPeerMessage, peers }) => {
     }
   };
 
+  // BUG: setMsg("") when using a <textarea> seems to instead set state to "\n"
+  // even in a default CRA application. For now, this will do.
+  const handleChange = (e) => {
+    if (e.target.value !== "\n") {
+      setMsg(e.target.value);
+    }
+  };
+
   return (
     <>
       <SelectedFileInput fileInput={fileInput} setFileInput={setFileInput} />
@@ -101,7 +109,7 @@ const ConversationFooter = ({ sendPeerMessage, peers }) => {
           placeholder="Type message here ..."
           onKeyDown={handleKeyDown}
           value={messageInput}
-          onChange={(e) => setMessageInput(e.target.value)}
+          onChange={handleChange}
         />
         <div className="flex">
           <FileUploader setFile={setFileInput} />

--- a/pages/d/chat.jsx
+++ b/pages/d/chat.jsx
@@ -663,6 +663,14 @@ const ConversationFooter = ({ sendBasicMessage, myDid }) => {
     }
   };
 
+  // BUG: setMsg("") when using a <textarea> seems to instead set state to "\n"
+  // even in a default CRA application. For now, this will do.
+  const handleChange = (e) => {
+    if (e.target.value !== "\n") {
+      setMsg(e.target.value);
+    }
+  };
+
   return (
     <div className="bg-white shadow">
       <SelectedFileInput fileInput={fileInput} setFileInput={setFileInput} />
@@ -677,7 +685,7 @@ const ConversationFooter = ({ sendBasicMessage, myDid }) => {
               ref={textAreaRef}
               value={msg}
               onKeyPress={handleKeyDown}
-              onChange={(e) => setMsg(e.target.value)}
+              onChange={handleChange}
               className="tracking-wide shadow-sm focus:ring-primary focus:border-primary border-primary border block w-full sm:text-sm border-gray-300 px-4 rounded-md pt-2"
               placeholder="Start a new message"
             />


### PR DESCRIPTION
Not quite sure why, but if state is reset on a `textarea` to `""` (i.e. `setMsg("")`), the final value will be `"\n"`. I tested this in a brand new CRA application and it seems to be default behavior. However, we want to clear out the msg state after each message has been sent, not leave a line break. Wasn't able to directly fix this, so instead I just blocked `"\n"` from being a state value. It's created a small side effect where you can't type a newline in the beginning of the textarea, but it's better than before. May have to revisit. 

Also, found a small formatting issue around the `New User` button during the onboarding flow. Fix this as well. 