### PR TITLE
switched to auth0 loginWithPopup

### DIFF
--- a/components/MainNavigation.jsx
+++ b/components/MainNavigation.jsx
@@ -240,8 +240,13 @@ const TwitterConnect = () => {
   const [, setAuth0Token] = useAtom(auth0TokenAtom);
   const router = useRouter();
 
-  const { user, isAuthenticated, loginWithRedirect, getAccessTokenSilently } =
-    useAuth0();
+  const {
+    user,
+    isAuthenticated,
+    loginWithRedirect,
+    getAccessTokenSilently,
+    loginWithPopup,
+  } = useAuth0();
 
   useEffect(() => {
     const getToken = async () => {
@@ -258,19 +263,12 @@ const TwitterConnect = () => {
     returnUrl = window.location.origin;
   }
 
-  const redirectAppState = {
-    appState: {
-      targetUrl: returnUrl,
-      pathname: router.pathname,
-    },
-  };
-
   return (
     <>
       {!isAuthenticated ? (
         <button
           type="button"
-          onClick={() => loginWithRedirect(redirectAppState)}
+          onClick={() => loginWithPopup()}
           className="text-white bg-blue-400 hover:bg-blue-500 focus:ring-4 focus:outline-none focus:ring-blue-400/50 font-medium rounded-lg text-sm px-5 py-2.5 text-center inline-flex items-center"
         >
           <svg

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -8,7 +8,6 @@ import { ErrorBoundary } from "react-error-boundary";
 import ErrorFallback from "../components/ErrorFallback";
 import { Auth0Provider } from "@auth0/auth0-react";
 import auth0Config from "../auth0_config.json";
-import { useRouter } from "next/router";
 import { Amplify } from "aws-amplify";
 import awsExports from "../aws-exports";
 import ApolloWrapper from "../components/ApolloWrapper";
@@ -33,25 +32,10 @@ const SafeHydrate = ({ children }) => {
 };
 
 function MyApp({ Component, pageProps }: AppProps) {
-  const router = useRouter();
-  const onRedirectCallback = (appState) => {
-    const { pathname } = appState;
-    router.push({
-      pathname,
-    });
-  };
-
-  let redirectUri = "";
-  if (typeof window !== "undefined") {
-    redirectUri = window.location.origin;
-  }
-
   const auth0ProviderConfig = {
     domain: auth0Config.domain,
     clientId: auth0Config.clientId,
     audience: auth0Config.audience,
-    redirectUri: redirectUri,
-    onRedirectCallback,
   };
 
   return (


### PR DESCRIPTION
Was running into some issues using the auth0 login with redirect flow, particularly around utilizing the `redirectUri` and whitelisting the callback URL as an extension. Figured it would be safer, and much cleaner, to use a `loginWithPopup` approach instead. Works well. 